### PR TITLE
Update goenv version

### DIFF
--- a/libexec/goenv
+++ b/libexec/goenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # goenv version
-version="0.0.2"
+version="0.0.3"
 
 # Bomb out if we hit an error, ever
 set -e


### PR DESCRIPTION
The latest tag is `0.0.3` but the version hasn't been bumped
