### PR TITLE
Latest golang download

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -75,6 +75,7 @@ fi
 
 # URL to download from
 download=$(download_url $version $platform $arch $extra)
+echo "Downloading: $download"
 
 # Can't get too clever here
 set +e


### PR DESCRIPTION
Supports installing Go 1.3, and correctly downloads older versions of Go (1.2.2 and older).  Possibly future versions of Go can be downloaded correctly too.
