### PR TITLE
Fix goenv install for 1.3.1 and later

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -54,6 +54,7 @@ function vercomp () {
     if [[ $1 == $2 ]]
     then
         echo 0
+        return
     fi
     local IFS=.
     local i ver1=($1) ver2=($2)
@@ -72,10 +73,12 @@ function vercomp () {
         if ((10#${ver1[i]} > 10#${ver2[i]}))
         then
             echo 1
+            return
         fi
         if ((10#${ver1[i]} < 10#${ver2[i]}))
         then
             echo 2
+            return
         fi
     done
 #    echo 0


### PR DESCRIPTION
There was a problem with the vercomp function that caused it to echo
more than once for some comparisons.  This would appear to be a side
effect of changing the stackoverflow function to echo instead of using
return value.

Comparing 1.2 and 1.3.1 is one of the cases that was echoing more than
once.  This then caused the test for `"$rtn" == "1"` to be false, which
meant that it was trying to use the old source URL.
