### PR TITLE
Fixed tag name mismatch (as 0.0.5 dropped the `v`).

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ rbenv, but for Go.
 To install the latest stable release:
 
 ```
-git clone -b v0.0.5 https://github.com/wfarr/goenv.git ~/.goenv
+git clone -b 0.0.5 https://github.com/wfarr/goenv.git ~/.goenv
 ```
 
 Then add the following to your shell config at the end:


### PR DESCRIPTION
`0.0.5` has dropped the leading `v` as compared to e.g. `v0.0.4`.
Adapted the README.md accordingly.
