### PR TITLE
Make README point at the correct tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ rbenv, but for Go.
 To install the latest stable release:
 
 ```
-git clone -b v0.0.5 https://github.com/wfarr/goenv.git ~/.goenv
+git clone -b 0.0.5 https://github.com/wfarr/goenv.git ~/.goenv
 ```
 
 Then add the following to your shell config at the end:


### PR DESCRIPTION
For 0.0.5 the tag name is "0.0.5" rather than the previous convention of "v0.0.x". README now points at this to reduce confusion.
