### PR TITLE
Allow `goenv exec` to execute abritrary commands.

### DIFF
--- a/libexec/goenv-exec
+++ b/libexec/goenv-exec
@@ -27,19 +27,6 @@ fi
 
 GOROOT="$GOENV_ROOT/versions/$GOENV_VERSION"
 
-# if the specified Go version lacks this bin, bail
-if [ ! -x "$GOROOT/bin/$1" ]; then
-  echo "goenv: \`$1' does not exist for $GOENV_VERSION" >&2
-
-  for version in "$(goenv versions)"; do
-    if [ -x "$GOENV_ROOT/versions/$version/bin/$1" ]; then
-      echo "  $version" >&2
-    fi
-  done
-
-  exit 1
-fi
-
 export GOENV_VERSION GOROOT
 
 # Put our bindir onto PATH


### PR DESCRIPTION
Not just commands that ship with a specific Go version.  Some commands
(eg `gorename`) require a GOROOT to be set pointing at a Go source tree.
Allowing `goenv exec` to run any command on the PATH will allow these to
work.