### PR TITLE
golang devs have changed the download URI again.

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -88,7 +88,7 @@ if [ "$rtn" == "1" ]
 then
     download="http://golang.org/dl/go${version}.${platform}-${arch}${extra}.tar.gz"
 else
-    download="https://go.googlecode.com/files/go${version}.${platform}-${arch}${extra}.tar.gz"
+    download="https://storage.googleapis.com/golang/go${version}.${platform}-${arch}${extra}.tar.gz"
 fi
 # Can't get too clever here
 set +e


### PR DESCRIPTION
 Fixes #12 updated the URI for downloading versions greater than go1.2