### PR TITLE
Drop support for old (<1.2) versions

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -43,53 +43,8 @@ if [ "$platform" = "darwin" ]; then
   fi
 fi
 
-
-
-
-function vercomp () {
-    # http://stackoverflow.com/questions/4023830
-    # 0: '='
-    # 1: '>'
-    # 2: '<'
-    if [[ $1 == $2 ]]
-    then
-        echo 0
-    fi
-    local IFS=.
-    local i ver1=($1) ver2=($2)
-    # fill empty fields in ver1 with zeros
-    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
-    do
-        ver1[i]=0
-    done
-    for ((i=0; i<${#ver1[@]}; i++))
-    do
-        if [[ -z ${ver2[i]} ]]
-        then
-            # fill empty fields in ver2 with zeros
-            ver2[i]=0
-        fi
-        if ((10#${ver1[i]} > 10#${ver2[i]}))
-        then
-            echo 1
-        fi
-        if ((10#${ver1[i]} < 10#${ver2[i]}))
-        then
-            echo 2
-        fi
-    done
-#    echo 0
-}
-
-
-rtn=$(vercomp ${version} 1.2)
 # URL to download from
-if [ "$rtn" == "1" ]
-then
-    download="http://golang.org/dl/go${version}.${platform}-${arch}${extra}.tar.gz"
-else
-    download="https://go.googlecode.com/files/go${version}.${platform}-${arch}${extra}.tar.gz"
-fi
+download="http://golang.org/dl/go${version}.${platform}-${arch}${extra}.tar.gz"
 # Can't get too clever here
 set +e
 


### PR DESCRIPTION
This simplifies the download URL generator, but drops support for installing old (<= 1.2) versions. I'd be in favor of adding support for old versions again, if there's a URL scheme that will work for them (in other words, not URLs for google code).

Closes #21 
cc @lukashes