### PR TITLE
Update download URI

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -34,17 +34,17 @@ fi
 
 if [ "$platform" = "darwin" ]; then
   # Since go version 1.2, osx packages were subdivided into 10.6 and 10.8
-  if [ "$version" = "1.2" -o "$version" \> "1.2" ]; then
+  # After version 1.4.2, the OS version postfix was dropped
+  if [ "$version" \> "1.4.2" ]; then
+    extra=""
+  elif [ "$version" = "1.2" -o "$version" \> "1.2" -o  "$version" \< "1.4.3" ]; then
     if [ "$(uname -r)" \> "12" ]; then
-      extra="-osx10.8"
+      extra="-osx10.6"
     else
       extra="-osx10.6"
     fi
   fi
 fi
-
-
-
 
 function vercomp () {
     # http://stackoverflow.com/questions/4023830

--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -33,7 +33,7 @@ else
 fi
 
 if [ "$platform" = "darwin" ]; then
-  # Since go version 1.2, osx packages were subdivided into 10.6 and 10.8
+  # Since go version 1.2, macOS packages were subdivided into 10.6 and 10.8
   # After version 1.4.2, the OS version postfix was dropped
   if [ "$version" \> "1.4.2" ]; then
     extra=""

--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -81,15 +81,8 @@ function vercomp () {
 #    echo 0
 }
 
+download="https://storage.googleapis.com/golang/go${version}.${platform}-${arch}${extra}.tar.gz"
 
-rtn=$(vercomp ${version} 1.2)
-# URL to download from
-if [ "$rtn" == "1" ]
-then
-    download="http://golang.org/dl/go${version}.${platform}-${arch}${extra}.tar.gz"
-else
-    download="https://go.googlecode.com/files/go${version}.${platform}-${arch}${extra}.tar.gz"
-fi
 # Can't get too clever here
 set +e
 


### PR DESCRIPTION
💁  The download URIs for Go have changed. This changeset updates the base URL and removes the unrequired version branching.

Closes #12 